### PR TITLE
Fixed the Tizen video player by adding the missing CSS property position absolute

### DIFF
--- a/js/core/device/tizen/player.js
+++ b/js/core/device/tizen/player.js
@@ -32,7 +32,7 @@ Device_Tizen_Player = (function(Events) {
 			this.isMute = false;
 			this.uhdMultiplier = (webapis.productinfo.isUdPanelSupported()) ? 1.5 : 1;   // ratio 1.5 for UHD models, 1.0 for normal model (used in .setDisplayRect())
 
-			this.$el.css({left : Math.round(this.left), top : Math.round(this.top), width: Math.round(this.width), height: Math.round(this.height)});
+			this.$el.css({position: "absolute", left : Math.round(this.left), top : Math.round(this.top), width: Math.round(this.width), height: Math.round(this.height)});
 
 			this.PLAYER = Device.PLAYER;
 	


### PR DESCRIPTION
Hi there,

Here is a small fix for displaying properly the video player on Tizen devices, without this CSS property the video won't show up.

I noticed the all the other players were setting the position as absolute (even the base Device class), except this one.
