### PR TITLE
Fixed loading of Device_HbbTV module

### DIFF
--- a/js/core/main.js
+++ b/js/core/main.js
@@ -96,7 +96,7 @@ Main = (function(global) {
 				var name = navigator.userAgent.match(/hbbtv\S*/i);   //e.g: HbbTV/1.2.1
 				var nameArr = name ? name[0].split('/') : [];
 				var version = nameArr.length > 1 ? nameArr[1] : '';
-				return ['hbbtv', version];
+				return ['HbbTV', version];
 			}
 			else if (navigator.userAgent.indexOf('Maple 5') >= 0) {
 				return ['samsung', '2010'];


### PR DESCRIPTION
Object **Device_Hbbtv** does not exist, so `global['Device_' + driverName]` does not load appropriate module. `Main.getDevice()` have to return **HbbTV** string, then it works fine.

